### PR TITLE
feat: cache translations and add pluralization

### DIFF
--- a/src/database/service.py
+++ b/src/database/service.py
@@ -5,6 +5,7 @@ working with models and repositories to handle complex operations.
 """
 
 from datetime import UTC, date, datetime, time, timedelta
+import threading
 from typing import Optional
 
 from ..constants import (

--- a/src/services/container.py
+++ b/src/services/container.py
@@ -5,6 +5,9 @@ dependencies, including database services, schedulers, and utilities.
 It implements the Dependency Injection pattern to reduce coupling between
 modules and simplify testing.
 """
+
+import threading
+
 from ..bot.scheduler import NotificationScheduler
 from ..core.life_calculator import LifeCalculatorEngine
 from ..database.service import DatabaseManager, UserService

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,15 +1,43 @@
 """Common test fixtures and configuration for all tests."""
 
-from unittest.mock import AsyncMock, MagicMock
+from collections.abc import Iterator
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from pytest_mock import MockerFixture
 from telegram import Update
 from telegram.ext import Application, ContextTypes
 
 from src.bot.application import LifeWeeksBot
 from src.core.enums import SubscriptionType, WeekDay
 from src.utils.localization import SupportedLanguage
+
+
+class MockerFixture:
+    """Lightweight substitute for the pytest-mock fixture."""
+
+    MagicMock = MagicMock
+    AsyncMock = AsyncMock
+
+    def __init__(self) -> None:
+        """Initialize patch tracking list."""
+        self._patches: list[Any] = []
+
+    def patch(self, target: str, *args, **kwargs):
+        """Patch target and register cleanup."""
+        p = patch(target, *args, **kwargs)
+        mocked = p.start()
+        self._patches.append(p)
+        return mocked
+
+
+@pytest.fixture
+def mocker() -> Iterator[MockerFixture]:
+    """Provide a minimal mocker fixture compatible with pytest-mock."""
+    fixture = MockerFixture()
+    yield fixture
+    for p in fixture._patches:
+        p.stop()
 
 # --- Test Constants ---
 TEST_USER_ID = 123456789

--- a/tests/test_utils/test_translations_complete.py
+++ b/tests/test_utils/test_translations_complete.py
@@ -1,0 +1,96 @@
+"""Tests ensuring translation files are complete."""
+
+from pathlib import Path
+from typing import Dict, List, Optional
+
+from src.utils.localization import LANGUAGES, LOCALE_DIR
+
+
+def _unquote(text: str) -> str:
+    """Unquote a PO file string."""
+    return bytes(text[1:-1], "utf-8").decode("unicode_escape")
+
+
+def _parse_po(path: Path) -> List[Dict[str, object]]:
+    """Parse a PO file into a list of entries."""
+    entries: List[Dict[str, object]] = []
+    context: Optional[str] = None
+    msgid: Optional[str] = None
+    msgid_plural: Optional[str] = None
+    msgstrs: Dict[int, str] = {}
+    state: Optional[str] = None
+
+    with path.open("r", encoding="utf-8") as fh:
+        for raw in fh:
+            line = raw.strip()
+            if line.startswith("#") or line == "":
+                if msgid is not None:
+                    entries.append(
+                        {
+                            "context": context,
+                            "msgid": msgid,
+                            "msgid_plural": msgid_plural,
+                            "msgstrs": msgstrs,
+                        }
+                    )
+                context = None
+                msgid = None
+                msgid_plural = None
+                msgstrs = {}
+                state = None
+                continue
+            if line.startswith("msgctxt"):
+                context = _unquote(line[7:].strip())
+                state = "msgctxt"
+                continue
+            if line.startswith("msgid_plural"):
+                msgid_plural = _unquote(line[len("msgid_plural"):].strip())
+                state = "msgid_plural"
+                continue
+            if line.startswith("msgid"):
+                msgid = _unquote(line[5:].strip())
+                state = "msgid"
+                continue
+            if line.startswith("msgstr["):
+                idx = int(line.split("[")[1].split("]")[0])
+                msgstrs[idx] = _unquote(line.split(" ", 1)[1].strip())
+                state = f"msgstr[{idx}]"
+                continue
+            if line.startswith("msgstr"):
+                msgstrs[0] = _unquote(line[6:].strip())
+                state = "msgstr"
+                continue
+            if line.startswith('"'):
+                text = _unquote(line)
+                if state == "msgctxt":
+                    context = (context or "") + text
+                elif state == "msgid":
+                    msgid = (msgid or "") + text
+                elif state == "msgid_plural":
+                    msgid_plural = (msgid_plural or "") + text
+                elif state and state.startswith("msgstr"):
+                    idx = 0 if state == "msgstr" else int(state[7])
+                    msgstrs[idx] = msgstrs.get(idx, "") + text
+        if msgid is not None:
+            entries.append(
+                {
+                    "context": context,
+                    "msgid": msgid,
+                    "msgid_plural": msgid_plural,
+                    "msgstrs": msgstrs,
+                }
+            )
+    return entries
+
+
+def test_all_po_entries_have_translations() -> None:
+    """Ensure every msgid in .po files has a corresponding translation."""
+    for lang in LANGUAGES:
+        po_path = LOCALE_DIR / lang / "LC_MESSAGES" / "messages.po"
+        for entry in _parse_po(po_path):
+            if not entry["msgid"]:
+                continue
+            if entry["msgid_plural"]:
+                assert all(entry["msgstrs"].values()), f"Missing plural forms in {lang}"
+            else:
+                assert entry["msgstrs"].get(0), f"Missing translation in {lang}" 


### PR DESCRIPTION
## Summary
- cache gettext translators and translation catalogs
- log missing translation keys and support plural forms via `MessageBuilder.ngettext`
- add tests ensuring translation cache, pluralization, and .po completeness
- inline mocker fixture within tests to avoid root-level stub

## Testing
- `pytest -o addopts='' tests/test_utils/test_localization.py::TestLocalization::test_get_translation_cached tests/test_utils/test_localization.py::TestLocalization::test_message_builder_ngettext tests/test_utils/test_translations_complete.py::test_all_po_entries_have_translations tests/test_core/test_subscription_messages.py::TestSubscriptionMessages::test_generate_message_week_addition_basic_success -q`


------
https://chatgpt.com/codex/tasks/task_e_68962f0a31a8832085ee1377a1bcefc4