### PR TITLE
fix(deps): pin APScheduler to 3.10.0 and update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This project helps users better understand the passage of time and motivates mor
 
 ### 1. Clone the repository:
 ```bash
-git clone <repository-url>
+git clone https://github.com/akhmialeuski/telegram_myweeks_life_bot.git
 cd telegram_myweeks_life_bot
 ```
 
@@ -35,6 +35,7 @@ source .venv/bin/activate  # On Windows: .venv\Scripts\activate
 
 ### 3. Install dependencies:
 ```bash
+pip install --upgrade pip
 pip install -r requirements.txt
 pip install -r requirements-dev.txt  # For development
 ```
@@ -49,11 +50,6 @@ Required environment variables:
 - `TELEGRAM_BOT_TOKEN` - Your Telegram bot token from BotFather
 - `CHAT_ID` - Your Telegram user ID for notifications
 
-### 5. Set up the database:
-```bash
-python scripts/setup_database.py
-```
-
 ## Database Setup
 
 The project uses SQLAlchemy 2.0 with Alembic for database migrations and SQLite as the default database.
@@ -63,7 +59,7 @@ The project uses SQLAlchemy 2.0 with Alembic for database migrations and SQLite 
 Run the setup script to create the database and apply migrations:
 
 ```bash
-python scripts/setup_database.py
+PYTHONPATH=. python scripts/setup_database.py
 ```
 
 ### Manual Migration Commands

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,6 @@ matplotlib==3.8.2
 Pillow==10.1.0
 SQLAlchemy==2.0.23
 alembic==1.13.1
-APScheduler>=3.10.0
+APScheduler==3.10.0
 typing-extensions==4.9.0
+Babel>=2.13.0


### PR DESCRIPTION
Fix RuntimeError on EC2 caused by APScheduler 3.11.0 breaking changes that require running event loop before scheduler start. APScheduler 3.11.0 strictly enforces existing event loop presence at scheduler.start() call, while 3.10.x versions were more tolerant and could create new event loop or defer initialization.

Functional Changes:
- Pin APScheduler version to 3.10.0 instead of >=3.10.0 to ensure consistent behavior across environments
- Add Babel>=2.13.0 to requirements.txt for localization and date/number formatting support
- Prevent scheduler initialization failures on fresh installations with latest APScheduler versions
- Ensure reproducible dependency installation across local and production environments

Refactoring Changes:
- Update README.md with actual GitHub repository URL (https://github.com/akhmialeuski/telegram_myweeks_life_bot.git)
- Add PYTHONPATH=. prefix to database setup command in documentation
- Add pip upgrade command to installation instructions for better dependency resolution
- Remove duplicate database setup section from README.md
- Improve documentation structure and installation workflow clarity

Root Cause:
- EC2 installed APScheduler 3.11.0 (latest available) due to >=3.10.0 specification
- Local environment had APScheduler 3.10.4 from earlier pip install execution
- Version 3.11.0 introduced stricter asyncio event loop validation in AsyncIOScheduler.start()
- Scheduler was initialized before telegram bot created event loop via run_polling()
- AsyncIOScheduler.start() calls asyncio.get_running_loop() which raises RuntimeError when no loop exists