### PR TITLE
fix(scheduler): start scheduler via post_init callback to ensure even…

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -263,6 +263,8 @@ def bot() -> LifeWeeksBot:
 def mock_application_builder(mocker: MockerFixture) -> MagicMock:
     """Provides a mocked Application.builder() chain for testing bot setup.
 
+    The builder chain supports post_init() method for registering callbacks.
+
     :param mocker: Pytest mocker fixture
     :type mocker: MockerFixture
     :returns: Mocked Application.builder() chain
@@ -270,7 +272,11 @@ def mock_application_builder(mocker: MockerFixture) -> MagicMock:
     """
     mock_app_class = mocker.patch("src.bot.application.Application")
     mock_app = MagicMock(spec=Application)
-    mock_app_class.builder.return_value.token.return_value.build.return_value = mock_app
+    mock_builder_chain = MagicMock()
+    mock_builder_chain.token.return_value = mock_builder_chain
+    mock_builder_chain.post_init.return_value = mock_builder_chain
+    mock_builder_chain.build.return_value = mock_app
+    mock_app_class.builder.return_value = mock_builder_chain
     return mock_app
 
 


### PR DESCRIPTION
…t loop exists

Fix RuntimeError: no running event loop when starting scheduler on first run with empty database. The scheduler was being started before run_polling() created the event loop, causing APScheduler AsyncIOScheduler to fail.

Functional Changes:
- Move scheduler startup from start() method to post_init callback
- Register post_init callback in setup() method via Application.builder().post_init()
- Add _post_init_scheduler_start() async method to handle scheduler startup after event loop is created
- Ensure scheduler starts only when event loop is running, compatible with APScheduler 3.10.0+ requirements

Refactoring Changes:
- Remove direct start_scheduler() call from start() method
- Update setup() to register post_init callback through builder chain
- Improve code organization by separating scheduler initialization from startup
- Update method documentation to reflect new startup flow

Test Changes:
- Add test_setup_registers_post_init_callback to verify post_init registration
- Add test_post_init_scheduler_start_with_scheduler to test scheduler startup with scheduler instance
- Add test_post_init_scheduler_start_without_scheduler to test graceful handling when scheduler is missing
- Update test_start_runs_polling_without_direct_scheduler_start to reflect new behavior
- Update mock_application_builder fixture to support post_init() method
- Achieve 91% code coverage for application.py module

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Move scheduler startup to Application.post_init callback and add tests, removing direct start from start().
> 
> - **Application (`src/bot/application.py`)**
>   - Register `builder.post_init(self._post_init_scheduler_start)` during `setup()` and build app from builder.
>   - Remove direct `start_scheduler` call from `start()`; scheduler now starts in `_post_init_scheduler_start`.
>   - Add async `_post_init_scheduler_start(application)` to start scheduler once the event loop is running.
>   - Keep `_setup_scheduler()` to configure and store scheduler in `bot_data`.
> - **Tests**
>   - Update `tests/conftest.py` to mock builder chain supporting `post_init()`.
>   - Add `test_setup_registers_post_init_callback` and tests for `_post_init_scheduler_start` with/without scheduler.
>   - Update start behavior test to assert polling runs without direct scheduler start.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6f20905d676648b4bcdc157993fba0ae506115a8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->