### PR TITLE
test(integration): add E2E coverage for timezone support

### DIFF
--- a/tests/constants.py
+++ b/tests/constants.py
@@ -1,0 +1,27 @@
+"""Shared test constants for timezone-related tests.
+
+This module provides constants used across unit and integration tests
+to avoid magic values and ensure consistency with production code.
+"""
+
+# Callback data (must match src.bot.handlers.settings.keyboards)
+CALLBACK_TIMEZONE_UTC: str = "timezone_UTC"
+CALLBACK_TIMEZONE_MOSCOW: str = "timezone_Europe/Moscow"
+CALLBACK_TIMEZONE_WARSAW: str = "timezone_Europe/Warsaw"
+CALLBACK_TIMEZONE_MINSK: str = "timezone_Europe/Minsk"
+CALLBACK_TIMEZONE_NEW_YORK: str = "timezone_America/New_York"
+CALLBACK_TIMEZONE_EUROPE_LONDON: str = "timezone_Europe/London"
+CALLBACK_TIMEZONE_OTHER: str = "timezone_other"
+CALLBACK_SETTINGS_TIMEZONE: str = "settings_timezone"
+
+# Fixed state values for deterministic tests (avoid time.time()/uuid.uuid4())
+TEST_STATE_TIMESTAMP: float = 1700000000.0
+TEST_STATE_ID: str = "test-state-id-12345"
+
+# IANA timezone identifiers for tests
+TIMEZONE_EUROPE_LONDON: str = "Europe/London"
+TIMEZONE_EUROPE_MINSK: str = "Europe/Minsk"
+TIMEZONE_EUROPE_MOSCOW: str = "Europe/Moscow"
+TIMEZONE_EUROPE_WARSAW: str = "Europe/Warsaw"
+TIMEZONE_AMERICA_NEW_YORK: str = "America/New_York"
+TIMEZONE_INVALID: str = "Invalid/Timezone"

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -309,6 +309,33 @@ async def make_premium_user(
     )
 
 
+async def make_trial_user(
+    container: ServiceContainer,
+    user_info: Any,
+    birth_date: date | None = None,
+    telegram_id: int | None = None,
+) -> None:
+    """Create a registered user with Trial subscription.
+
+    :param container: Service container with database connection
+    :type container: ServiceContainer
+    :param user_info: Mock or real Telegram User object (must have .id)
+    :type user_info: Any
+    :param birth_date: Birth date for the user (default: 1990-01-01)
+    :type birth_date: date | None
+    :param telegram_id: Telegram ID to upgrade (default: user_info.id)
+    :type telegram_id: int | None
+    :returns: None
+    :rtype: None
+    """
+    await make_registered_user(container, user_info, birth_date)
+    tid = telegram_id if telegram_id is not None else user_info.id
+    await container.user_service.update_user_subscription(
+        telegram_id=tid,
+        subscription_type=SubscriptionType.TRIAL,
+    )
+
+
 def setup_notification_schedule_callback(mock_update: MagicMock) -> None:
     """Configure mock_update for notification schedule callback flow.
 
@@ -319,6 +346,26 @@ def setup_notification_schedule_callback(mock_update: MagicMock) -> None:
     """
     mock_update.callback_query = MagicMock()
     mock_update.callback_query.data = "settings_notification_schedule"
+    mock_update.callback_query.edit_message_text = AsyncMock()
+    mock_update.callback_query.answer = AsyncMock()
+
+
+def setup_timezone_callback(
+    mock_update: MagicMock,
+    callback_data: str = "settings_timezone",
+) -> None:
+    """Configure mock_update for timezone settings callback flow.
+
+    :param mock_update: Mock Telegram Update object
+    :type mock_update: MagicMock
+    :param callback_data: Callback data string (default: settings_timezone)
+    :type callback_data: str
+    :returns: None
+    :rtype: None
+    """
+    mock_update.message = None
+    mock_update.callback_query = MagicMock()
+    mock_update.callback_query.data = callback_data
     mock_update.callback_query.edit_message_text = AsyncMock()
     mock_update.callback_query.answer = AsyncMock()
 

--- a/tests/integration/test_settings_timezone.py
+++ b/tests/integration/test_settings_timezone.py
@@ -13,8 +13,6 @@ Test Groups:
     - TestTimezoneOutputAllLanguages: Output verification per language
 """
 
-import time
-import uuid
 from datetime import time as datetime_time
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -27,9 +25,26 @@ from src.bot.event_listeners import register_event_listeners
 from src.bot.handlers.settings.dispatcher import SettingsDispatcher
 from src.bot.handlers.settings.timezone_handler import TimezoneHandler
 from src.bot.handlers.start_handler import StartHandler
+from src.bot.notification_schedule import WEEKDAY_MAP
 from src.constants import DEFAULT_TIMEZONE
 from src.enums import NotificationFrequency, SupportedLanguage, WeekDay
 from src.services.container import ServiceContainer
+from tests.constants import (
+    CALLBACK_TIMEZONE_MINSK,
+    CALLBACK_TIMEZONE_MOSCOW,
+    CALLBACK_TIMEZONE_NEW_YORK,
+    CALLBACK_TIMEZONE_OTHER,
+    CALLBACK_TIMEZONE_UTC,
+    CALLBACK_TIMEZONE_WARSAW,
+    TEST_STATE_ID,
+    TEST_STATE_TIMESTAMP,
+    TIMEZONE_AMERICA_NEW_YORK,
+    TIMEZONE_EUROPE_LONDON,
+    TIMEZONE_EUROPE_MINSK,
+    TIMEZONE_EUROPE_MOSCOW,
+    TIMEZONE_EUROPE_WARSAW,
+    TIMEZONE_INVALID,
+)
 from tests.integration.conftest import (
     TEST_USER_ID,
     get_reply_text,
@@ -39,18 +54,6 @@ from tests.integration.conftest import (
     set_message_text,
     setup_timezone_callback,
 )
-
-# Timezone callback constants (from keyboards.py)
-CALLBACK_TIMEZONE_UTC: str = "timezone_UTC"
-CALLBACK_TIMEZONE_MOSCOW: str = "timezone_Europe/Moscow"
-CALLBACK_TIMEZONE_WARSAW: str = "timezone_Europe/Warsaw"
-CALLBACK_TIMEZONE_MINSK: str = "timezone_Europe/Minsk"
-CALLBACK_TIMEZONE_NEW_YORK: str = "timezone_America/New_York"
-CALLBACK_TIMEZONE_OTHER: str = "timezone_other"
-
-# IANA timezone identifiers
-TIMEZONE_EUROPE_LONDON: str = "Europe/London"
-TIMEZONE_INVALID: str = "Invalid/Timezone"
 
 
 def setup_awaiting_timezone_state(mock_context: MagicMock) -> None:
@@ -62,8 +65,8 @@ def setup_awaiting_timezone_state(mock_context: MagicMock) -> None:
     """
     mock_context.user_data = {
         STATE_KEY: ConversationState.AWAITING_SETTINGS_TIMEZONE.value,
-        TIMESTAMP_KEY: time.time(),
-        STATE_ID_KEY: str(uuid.uuid4()),
+        TIMESTAMP_KEY: TEST_STATE_TIMESTAMP,
+        STATE_ID_KEY: TEST_STATE_ID,
     }
 
 
@@ -122,8 +125,8 @@ class TestTimezoneRegistrationDefaults:
         mock_telegram_user.language_code = language.value
         mock_context.user_data = {
             STATE_KEY: ConversationState.AWAITING_START_BIRTH_DATE.value,
-            TIMESTAMP_KEY: time.time(),
-            STATE_ID_KEY: str(uuid.uuid4()),
+            TIMESTAMP_KEY: TEST_STATE_TIMESTAMP,
+            STATE_ID_KEY: TEST_STATE_ID,
         }
         set_message_text(mock_update=mock_update, text="01.01.1995")
 
@@ -184,10 +187,10 @@ class TestTimezoneHandlerPremiumUser:
         "callback_data,expected_tz",
         [
             (CALLBACK_TIMEZONE_UTC, "UTC"),
-            (CALLBACK_TIMEZONE_MOSCOW, "Europe/Moscow"),
-            (CALLBACK_TIMEZONE_WARSAW, "Europe/Warsaw"),
-            (CALLBACK_TIMEZONE_MINSK, "Europe/Minsk"),
-            (CALLBACK_TIMEZONE_NEW_YORK, "America/New_York"),
+            (CALLBACK_TIMEZONE_MOSCOW, TIMEZONE_EUROPE_MOSCOW),
+            (CALLBACK_TIMEZONE_WARSAW, TIMEZONE_EUROPE_WARSAW),
+            (CALLBACK_TIMEZONE_MINSK, TIMEZONE_EUROPE_MINSK),
+            (CALLBACK_TIMEZONE_NEW_YORK, TIMEZONE_AMERICA_NEW_YORK),
         ],
     )
     async def test_premium_select_from_keyboard_updates_timezone(
@@ -371,7 +374,7 @@ class TestTimezoneHandlerTrialUser:
             TEST_USER_ID
         )
         assert profile is not None
-        assert profile.settings.timezone == "Europe/Moscow"
+        assert profile.settings.timezone == TIMEZONE_EUROPE_MOSCOW
 
 
 @pytest.mark.integration
@@ -480,7 +483,7 @@ class TestTimezoneSchedulerApplication:
         scheduler_client.schedule_job.assert_awaited_once()
         call_kwargs = scheduler_client.schedule_job.call_args.kwargs
         trigger = call_kwargs["trigger"]
-        assert trigger.timezone == "Europe/Moscow"
+        assert trigger.timezone == TIMEZONE_EUROPE_MOSCOW
         assert trigger.hour == 10
         assert trigger.minute == 0
 
@@ -509,7 +512,7 @@ class TestTimezoneSchedulerApplication:
             notification_frequency=NotificationFrequency.WEEKLY,
             notifications_day=WeekDay.FRIDAY,
             notifications_time=datetime_time(14, 30),
-            timezone="Europe/Warsaw",
+            timezone=TIMEZONE_EUROPE_WARSAW,
         )
 
         scheduler_client = AsyncMock()
@@ -533,10 +536,10 @@ class TestTimezoneSchedulerApplication:
         scheduler_client.schedule_job.assert_awaited_once()
         call_kwargs = scheduler_client.schedule_job.call_args.kwargs
         trigger = call_kwargs["trigger"]
-        assert trigger.timezone == "Europe/Moscow"
+        assert trigger.timezone == TIMEZONE_EUROPE_MOSCOW
         assert trigger.hour == 14
         assert trigger.minute == 30
-        assert trigger.day_of_week == 4  # Friday
+        assert trigger.day_of_week == WEEKDAY_MAP[WeekDay.FRIDAY]
 
 
 @pytest.mark.integration
@@ -581,7 +584,7 @@ class TestTimezoneOutputAllLanguages:
 
         call_kwargs = mock_update.callback_query.edit_message_text.call_args.kwargs
         text = call_kwargs["text"]
-        assert "Europe/Moscow" in text
+        assert TIMEZONE_EUROPE_MOSCOW in text
         assert text  # Non-empty response
 
     @pytest.mark.parametrize("language", list(SupportedLanguage))

--- a/tests/integration/test_settings_timezone.py
+++ b/tests/integration/test_settings_timezone.py
@@ -1,0 +1,618 @@
+"""Integration tests for timezone support.
+
+This module provides comprehensive E2E testing for timezone functionality,
+covering registration defaults, handler flows, scheduler application,
+and output verification across all supported languages.
+
+Test Groups:
+    - TestTimezoneRegistrationDefaults: Default timezone on registration
+    - TestTimezoneHandlerPremiumUser: Premium user timezone changes
+    - TestTimezoneHandlerTrialUser: Trial user timezone access
+    - TestTimezoneHandlerBasicUser: Basic user access control
+    - TestTimezoneSchedulerApplication: Scheduler receives correct trigger
+    - TestTimezoneOutputAllLanguages: Output verification per language
+"""
+
+import time
+import uuid
+from datetime import time as datetime_time
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.bot.constants import DEFAULT_TIMEZONE_MAPPING, FALLBACK_TIMEZONE
+from src.bot.conversations.persistence import STATE_ID_KEY, STATE_KEY, TIMESTAMP_KEY
+from src.bot.conversations.states import ConversationState
+from src.bot.event_listeners import register_event_listeners
+from src.bot.handlers.settings.dispatcher import SettingsDispatcher
+from src.bot.handlers.settings.timezone_handler import TimezoneHandler
+from src.bot.handlers.start_handler import StartHandler
+from src.constants import DEFAULT_TIMEZONE
+from src.enums import NotificationFrequency, SupportedLanguage, WeekDay
+from src.services.container import ServiceContainer
+from tests.integration.conftest import (
+    TEST_USER_ID,
+    get_reply_text,
+    make_premium_user,
+    make_registered_user,
+    make_trial_user,
+    set_message_text,
+    setup_timezone_callback,
+)
+
+# Timezone callback constants (from keyboards.py)
+CALLBACK_TIMEZONE_UTC: str = "timezone_UTC"
+CALLBACK_TIMEZONE_MOSCOW: str = "timezone_Europe/Moscow"
+CALLBACK_TIMEZONE_WARSAW: str = "timezone_Europe/Warsaw"
+CALLBACK_TIMEZONE_MINSK: str = "timezone_Europe/Minsk"
+CALLBACK_TIMEZONE_NEW_YORK: str = "timezone_America/New_York"
+CALLBACK_TIMEZONE_OTHER: str = "timezone_other"
+
+# IANA timezone identifiers
+TIMEZONE_EUROPE_LONDON: str = "Europe/London"
+TIMEZONE_INVALID: str = "Invalid/Timezone"
+
+
+def setup_awaiting_timezone_state(mock_context: MagicMock) -> None:
+    """Set mock_context.user_data to AWAITING_SETTINGS_TIMEZONE state.
+
+    :param mock_context: Mock Telegram Context object
+    :type mock_context: MagicMock
+    :returns: None
+    """
+    mock_context.user_data = {
+        STATE_KEY: ConversationState.AWAITING_SETTINGS_TIMEZONE.value,
+        TIMESTAMP_KEY: time.time(),
+        STATE_ID_KEY: str(uuid.uuid4()),
+    }
+
+
+def get_expected_timezone_for_language(language: SupportedLanguage) -> str:
+    """Get expected default timezone for a language.
+
+    :param language: Supported language enum
+    :type language: SupportedLanguage
+    :returns: IANA timezone string
+    :rtype: str
+    """
+    return DEFAULT_TIMEZONE_MAPPING.get(language, FALLBACK_TIMEZONE)
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+class TestTimezoneRegistrationDefaults:
+    """Tests for default timezone on user registration."""
+
+    @pytest.fixture
+    def handler(self, test_service_container: ServiceContainer) -> StartHandler:
+        return StartHandler(services=test_service_container)
+
+    @pytest.mark.parametrize("language", list(SupportedLanguage))
+    async def test_registration_sets_default_timezone_by_language(
+        self,
+        handler: StartHandler,
+        mock_update: MagicMock,
+        mock_context: MagicMock,
+        mock_telegram_user: MagicMock,
+        test_service_container: ServiceContainer,
+        language: SupportedLanguage,
+    ) -> None:
+        """Test that registration sets default timezone from user language.
+
+        Preconditions:
+            - User is not registered
+            - User language_code matches parametrized language
+
+        Test Steps:
+            1. Set AWAITING_START_BIRTH_DATE state
+            2. User sends valid birth date
+            3. Handler processes registration
+
+        Post-conditions:
+            - profile.settings.timezone == DEFAULT_TIMEZONE_MAPPING[language]
+
+        :param handler: StartHandler instance
+        :param mock_update: Mock Telegram Update
+        :param mock_context: Mock Telegram Context
+        :param mock_telegram_user: Mock Telegram User
+        :param test_service_container: ServiceContainer
+        :param language: Parametrized SupportedLanguage
+        :returns: None
+        """
+        mock_telegram_user.language_code = language.value
+        mock_context.user_data = {
+            STATE_KEY: ConversationState.AWAITING_START_BIRTH_DATE.value,
+            TIMESTAMP_KEY: time.time(),
+            STATE_ID_KEY: str(uuid.uuid4()),
+        }
+        set_message_text(mock_update=mock_update, text="01.01.1995")
+
+        await handler.handle_birth_date_input(update=mock_update, context=mock_context)
+
+        profile = await test_service_container.user_service.get_user_profile(
+            TEST_USER_ID
+        )
+        assert profile is not None
+        expected_tz = get_expected_timezone_for_language(language)
+        assert profile.settings.timezone == expected_tz
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+class TestTimezoneHandlerPremiumUser:
+    """Tests for Premium user timezone handler flows."""
+
+    @pytest.fixture
+    def handler(self, test_service_container: ServiceContainer) -> TimezoneHandler:
+        return TimezoneHandler(services=test_service_container)
+
+    @pytest.mark.parametrize("language", list(SupportedLanguage))
+    async def test_premium_callback_shows_timezone_menu(
+        self,
+        handler: TimezoneHandler,
+        mock_update: MagicMock,
+        mock_context: MagicMock,
+        mock_telegram_user: MagicMock,
+        test_service_container: ServiceContainer,
+        language: SupportedLanguage,
+    ) -> None:
+        """Test Premium user sees timezone selection menu on callback.
+
+        :param handler: TimezoneHandler instance
+        :param mock_update: Mock Telegram Update
+        :param mock_context: Mock Telegram Context
+        :param mock_telegram_user: Mock Telegram User
+        :param test_service_container: ServiceContainer
+        :param language: Parametrized SupportedLanguage
+        :returns: None
+        """
+        await make_premium_user(test_service_container, mock_telegram_user)
+        await test_service_container.user_service.update_user_settings(
+            telegram_id=TEST_USER_ID, language=language.value
+        )
+        setup_timezone_callback(mock_update)
+        mock_update.effective_user = mock_telegram_user
+
+        await handler.handle_callback(update=mock_update, context=mock_context)
+
+        mock_update.callback_query.edit_message_text.assert_called_once()
+        call_kwargs = mock_update.callback_query.edit_message_text.call_args.kwargs
+        assert call_kwargs["text"], "Message text must be non-empty"
+        assert call_kwargs.get("reply_markup") is not None
+
+    @pytest.mark.parametrize(
+        "callback_data,expected_tz",
+        [
+            (CALLBACK_TIMEZONE_UTC, "UTC"),
+            (CALLBACK_TIMEZONE_MOSCOW, "Europe/Moscow"),
+            (CALLBACK_TIMEZONE_WARSAW, "Europe/Warsaw"),
+            (CALLBACK_TIMEZONE_MINSK, "Europe/Minsk"),
+            (CALLBACK_TIMEZONE_NEW_YORK, "America/New_York"),
+        ],
+    )
+    async def test_premium_select_from_keyboard_updates_timezone(
+        self,
+        handler: TimezoneHandler,
+        mock_update: MagicMock,
+        mock_context: MagicMock,
+        mock_telegram_user: MagicMock,
+        test_service_container: ServiceContainer,
+        callback_data: str,
+        expected_tz: str,
+    ) -> None:
+        """Test Premium user selecting timezone from keyboard updates DB.
+
+        :param handler: TimezoneHandler instance
+        :param mock_update: Mock Telegram Update
+        :param mock_context: Mock Telegram Context
+        :param mock_telegram_user: Mock Telegram User
+        :param test_service_container: ServiceContainer
+        :param callback_data: Callback data string
+        :param expected_tz: Expected timezone value
+        :returns: None
+        """
+        await make_premium_user(test_service_container, mock_telegram_user)
+        setup_timezone_callback(mock_update, callback_data=callback_data)
+        mock_update.effective_user = mock_telegram_user
+
+        await handler.handle_selection_callback(
+            update=mock_update, context=mock_context
+        )
+
+        profile = await test_service_container.user_service.get_user_profile(
+            TEST_USER_ID
+        )
+        assert profile is not None
+        assert profile.settings.timezone == expected_tz
+
+    @pytest.mark.parametrize("language", list(SupportedLanguage))
+    async def test_premium_manual_input_valid_iana_success(
+        self,
+        handler: TimezoneHandler,
+        mock_update: MagicMock,
+        mock_context: MagicMock,
+        mock_telegram_user: MagicMock,
+        test_service_container: ServiceContainer,
+        language: SupportedLanguage,
+    ) -> None:
+        """Test Premium user manual IANA timezone input succeeds.
+
+        :param handler: TimezoneHandler instance
+        :param mock_update: Mock Telegram Update
+        :param mock_context: Mock Telegram Context
+        :param mock_telegram_user: Mock Telegram User
+        :param test_service_container: ServiceContainer
+        :param language: Parametrized SupportedLanguage
+        :returns: None
+        """
+        await make_premium_user(test_service_container, mock_telegram_user)
+        await test_service_container.user_service.update_user_settings(
+            telegram_id=TEST_USER_ID, language=language.value
+        )
+        setup_awaiting_timezone_state(mock_context)
+        set_message_text(mock_update=mock_update, text=TIMEZONE_EUROPE_LONDON)
+
+        await handler.handle_input(update=mock_update, context=mock_context)
+
+        profile = await test_service_container.user_service.get_user_profile(
+            TEST_USER_ID
+        )
+        assert profile is not None
+        assert profile.settings.timezone == TIMEZONE_EUROPE_LONDON
+
+    @pytest.mark.parametrize("language", list(SupportedLanguage))
+    async def test_premium_manual_input_invalid_iana_keeps_state(
+        self,
+        handler: TimezoneHandler,
+        mock_update: MagicMock,
+        mock_context: MagicMock,
+        mock_telegram_user: MagicMock,
+        test_service_container: ServiceContainer,
+        language: SupportedLanguage,
+    ) -> None:
+        """Test Premium user invalid IANA input keeps awaiting state.
+
+        :param handler: TimezoneHandler instance
+        :param mock_update: Mock Telegram Update
+        :param mock_context: Mock Telegram Context
+        :param mock_telegram_user: Mock Telegram User
+        :param test_service_container: ServiceContainer
+        :param language: Parametrized SupportedLanguage
+        :returns: None
+        """
+        await make_premium_user(test_service_container, mock_telegram_user)
+        await test_service_container.user_service.update_user_settings(
+            telegram_id=TEST_USER_ID, language=language.value
+        )
+        setup_awaiting_timezone_state(mock_context)
+        set_message_text(mock_update=mock_update, text=TIMEZONE_INVALID)
+
+        await handler.handle_input(update=mock_update, context=mock_context)
+
+        reply_text = get_reply_text(mock_message=mock_update.message)
+        assert reply_text is not None
+        assert len(reply_text) > 0
+        assert (
+            mock_context.user_data.get(STATE_KEY)
+            == ConversationState.AWAITING_SETTINGS_TIMEZONE.value
+        )
+
+    @pytest.mark.parametrize("language", list(SupportedLanguage))
+    async def test_premium_select_other_prompts_manual_input(
+        self,
+        handler: TimezoneHandler,
+        mock_update: MagicMock,
+        mock_context: MagicMock,
+        mock_telegram_user: MagicMock,
+        test_service_container: ServiceContainer,
+        language: SupportedLanguage,
+    ) -> None:
+        """Test Premium user selecting Other prompts for manual input.
+
+        :param handler: TimezoneHandler instance
+        :param mock_update: Mock Telegram Update
+        :param mock_context: Mock Telegram Context
+        :param mock_telegram_user: Mock Telegram User
+        :param test_service_container: ServiceContainer
+        :param language: Parametrized SupportedLanguage
+        :returns: None
+        """
+        await make_premium_user(test_service_container, mock_telegram_user)
+        await test_service_container.user_service.update_user_settings(
+            telegram_id=TEST_USER_ID, language=language.value
+        )
+        setup_timezone_callback(mock_update, callback_data=CALLBACK_TIMEZONE_OTHER)
+        mock_update.effective_user = mock_telegram_user
+
+        result = await handler.handle_selection_callback(
+            update=mock_update, context=mock_context
+        )
+
+        assert result == ConversationState.AWAITING_SETTINGS_TIMEZONE.value
+        call_kwargs = mock_update.callback_query.edit_message_text.call_args.kwargs
+        assert call_kwargs["text"], "Manual input prompt must be shown"
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+class TestTimezoneHandlerTrialUser:
+    """Tests for Trial user timezone access (same as Premium)."""
+
+    @pytest.fixture
+    def handler(self, test_service_container: ServiceContainer) -> TimezoneHandler:
+        return TimezoneHandler(services=test_service_container)
+
+    async def test_trial_user_can_change_timezone(
+        self,
+        handler: TimezoneHandler,
+        mock_update: MagicMock,
+        mock_context: MagicMock,
+        mock_telegram_user: MagicMock,
+        test_service_container: ServiceContainer,
+    ) -> None:
+        """Test Trial user can change timezone via keyboard selection.
+
+        :param handler: TimezoneHandler instance
+        :param mock_update: Mock Telegram Update
+        :param mock_context: Mock Telegram Context
+        :param mock_telegram_user: Mock Telegram User
+        :param test_service_container: ServiceContainer
+        :returns: None
+        """
+        await make_trial_user(test_service_container, mock_telegram_user)
+        setup_timezone_callback(mock_update, callback_data=CALLBACK_TIMEZONE_MOSCOW)
+        mock_update.effective_user = mock_telegram_user
+
+        await handler.handle_selection_callback(
+            update=mock_update, context=mock_context
+        )
+
+        profile = await test_service_container.user_service.get_user_profile(
+            TEST_USER_ID
+        )
+        assert profile is not None
+        assert profile.settings.timezone == "Europe/Moscow"
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+class TestTimezoneHandlerBasicUser:
+    """Tests for Basic user access control (no timezone button)."""
+
+    async def test_basic_user_settings_menu_no_timezone_button(
+        self,
+        test_service_container: ServiceContainer,
+        mock_update: MagicMock,
+        mock_context: MagicMock,
+        mock_telegram_user: MagicMock,
+    ) -> None:
+        """Test Basic user does not see timezone button in settings menu.
+
+        :param test_service_container: ServiceContainer
+        :param mock_update: Mock Telegram Update
+        :param mock_context: Mock Telegram Context
+        :param mock_telegram_user: Mock Telegram User
+        :returns: None
+        """
+        await make_registered_user(test_service_container, mock_telegram_user)
+        dispatcher = SettingsDispatcher(services=test_service_container)
+        set_message_text(mock_update=mock_update, text="/settings")
+
+        await dispatcher.handle(update=mock_update, context=mock_context)
+
+        reply_markup = mock_update.message.reply_text.call_args.kwargs.get(
+            "reply_markup"
+        )
+        assert reply_markup is not None
+        callback_datas = []
+        for row in reply_markup.inline_keyboard:
+            for btn in row:
+                if hasattr(btn, "callback_data") and btn.callback_data:
+                    callback_datas.append(btn.callback_data)
+        assert "settings_timezone" not in callback_datas
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+class TestTimezoneSchedulerApplication:
+    """Tests for scheduler receiving correct trigger on timezone change."""
+
+    @pytest.fixture
+    def handler(self, test_service_container: ServiceContainer) -> TimezoneHandler:
+        return TimezoneHandler(services=test_service_container)
+
+    async def test_timezone_change_publishes_event_and_scheduler_receives_correct_trigger(
+        self,
+        handler: TimezoneHandler,
+        mock_update: MagicMock,
+        mock_context: MagicMock,
+        mock_telegram_user: MagicMock,
+        test_service_container: ServiceContainer,
+    ) -> None:
+        """Test timezone change triggers scheduler with correct timezone.
+
+        Preconditions:
+            - Premium user with DAILY schedule, 10:00, timezone UTC
+
+        Test Steps:
+            1. User selects Europe/Moscow via callback
+            2. Event published, handle_user_settings_changed runs
+            3. Scheduler receives schedule_job with trigger.timezone
+
+        Post-conditions:
+            - schedule_job called with trigger.timezone == Europe/Moscow
+
+        :param handler: TimezoneHandler instance
+        :param mock_update: Mock Telegram Update
+        :param mock_context: Mock Telegram Context
+        :param mock_telegram_user: Mock Telegram User
+        :param test_service_container: ServiceContainer
+        :returns: None
+        """
+        register_event_listeners(test_service_container)
+        user_service = test_service_container.user_service
+        await make_premium_user(test_service_container, mock_telegram_user)
+        await user_service.update_user_settings(
+            telegram_id=TEST_USER_ID,
+            notification_frequency=NotificationFrequency.DAILY,
+            notifications_time=datetime_time(10, 0),
+            timezone=DEFAULT_TIMEZONE,
+        )
+
+        scheduler_client = AsyncMock()
+        scheduler_client.schedule_job.return_value = True
+
+        container_for_listener = MagicMock()
+        container_for_listener.get_scheduler_client.return_value = scheduler_client
+        container_for_listener.get_user_service.return_value = user_service
+
+        setup_timezone_callback(mock_update, callback_data=CALLBACK_TIMEZONE_MOSCOW)
+        mock_update.effective_user = mock_telegram_user
+
+        with patch(
+            target="src.bot.event_listeners.ServiceContainer",
+            return_value=container_for_listener,
+        ):
+            await handler.handle_selection_callback(
+                update=mock_update, context=mock_context
+            )
+
+        scheduler_client.schedule_job.assert_awaited_once()
+        call_kwargs = scheduler_client.schedule_job.call_args.kwargs
+        trigger = call_kwargs["trigger"]
+        assert trigger.timezone == "Europe/Moscow"
+        assert trigger.hour == 10
+        assert trigger.minute == 0
+
+    async def test_timezone_change_reschedules_with_correct_time(
+        self,
+        handler: TimezoneHandler,
+        mock_update: MagicMock,
+        mock_context: MagicMock,
+        mock_telegram_user: MagicMock,
+        test_service_container: ServiceContainer,
+    ) -> None:
+        """Test timezone change preserves schedule time (weekly Friday 14:30).
+
+        :param handler: TimezoneHandler instance
+        :param mock_update: Mock Telegram Update
+        :param mock_context: Mock Telegram Context
+        :param mock_telegram_user: Mock Telegram User
+        :param test_service_container: ServiceContainer
+        :returns: None
+        """
+        register_event_listeners(test_service_container)
+        user_service = test_service_container.user_service
+        await make_premium_user(test_service_container, mock_telegram_user)
+        await user_service.update_user_settings(
+            telegram_id=TEST_USER_ID,
+            notification_frequency=NotificationFrequency.WEEKLY,
+            notifications_day=WeekDay.FRIDAY,
+            notifications_time=datetime_time(14, 30),
+            timezone="Europe/Warsaw",
+        )
+
+        scheduler_client = AsyncMock()
+        scheduler_client.schedule_job.return_value = True
+
+        container_for_listener = MagicMock()
+        container_for_listener.get_scheduler_client.return_value = scheduler_client
+        container_for_listener.get_user_service.return_value = user_service
+
+        setup_timezone_callback(mock_update, callback_data=CALLBACK_TIMEZONE_MOSCOW)
+        mock_update.effective_user = mock_telegram_user
+
+        with patch(
+            target="src.bot.event_listeners.ServiceContainer",
+            return_value=container_for_listener,
+        ):
+            await handler.handle_selection_callback(
+                update=mock_update, context=mock_context
+            )
+
+        scheduler_client.schedule_job.assert_awaited_once()
+        call_kwargs = scheduler_client.schedule_job.call_args.kwargs
+        trigger = call_kwargs["trigger"]
+        assert trigger.timezone == "Europe/Moscow"
+        assert trigger.hour == 14
+        assert trigger.minute == 30
+        assert trigger.day_of_week == 4  # Friday
+
+
+@pytest.mark.integration
+@pytest.mark.asyncio
+class TestTimezoneOutputAllLanguages:
+    """Tests for timezone output verification across all languages."""
+
+    @pytest.fixture
+    def handler(self, test_service_container: ServiceContainer) -> TimezoneHandler:
+        return TimezoneHandler(services=test_service_container)
+
+    @pytest.mark.parametrize("language", list(SupportedLanguage))
+    async def test_timezone_success_message_in_all_languages(
+        self,
+        handler: TimezoneHandler,
+        mock_update: MagicMock,
+        mock_context: MagicMock,
+        mock_telegram_user: MagicMock,
+        test_service_container: ServiceContainer,
+        language: SupportedLanguage,
+    ) -> None:
+        """Test timezone success message contains new timezone in all languages.
+
+        :param handler: TimezoneHandler instance
+        :param mock_update: Mock Telegram Update
+        :param mock_context: Mock Telegram Context
+        :param mock_telegram_user: Mock Telegram User
+        :param test_service_container: ServiceContainer
+        :param language: Parametrized SupportedLanguage
+        :returns: None
+        """
+        await make_premium_user(test_service_container, mock_telegram_user)
+        await test_service_container.user_service.update_user_settings(
+            telegram_id=TEST_USER_ID, language=language.value
+        )
+        setup_timezone_callback(mock_update, callback_data=CALLBACK_TIMEZONE_MOSCOW)
+        mock_update.effective_user = mock_telegram_user
+
+        await handler.handle_selection_callback(
+            update=mock_update, context=mock_context
+        )
+
+        call_kwargs = mock_update.callback_query.edit_message_text.call_args.kwargs
+        text = call_kwargs["text"]
+        assert "Europe/Moscow" in text
+        assert text  # Non-empty response
+
+    @pytest.mark.parametrize("language", list(SupportedLanguage))
+    async def test_timezone_invalid_message_in_all_languages(
+        self,
+        handler: TimezoneHandler,
+        mock_update: MagicMock,
+        mock_context: MagicMock,
+        mock_telegram_user: MagicMock,
+        test_service_container: ServiceContainer,
+        language: SupportedLanguage,
+    ) -> None:
+        """Test invalid timezone error message in all languages.
+
+        :param handler: TimezoneHandler instance
+        :param mock_update: Mock Telegram Update
+        :param mock_context: Mock Telegram Context
+        :param mock_telegram_user: Mock Telegram User
+        :param test_service_container: ServiceContainer
+        :param language: Parametrized SupportedLanguage
+        :returns: None
+        """
+        await make_premium_user(test_service_container, mock_telegram_user)
+        await test_service_container.user_service.update_user_settings(
+            telegram_id=TEST_USER_ID, language=language.value
+        )
+        setup_awaiting_timezone_state(mock_context)
+        set_message_text(mock_update=mock_update, text=TIMEZONE_INVALID)
+
+        await handler.handle_input(update=mock_update, context=mock_context)
+
+        reply_text = get_reply_text(mock_message=mock_update.message)
+        assert reply_text is not None
+        assert len(reply_text) > 0

--- a/tests/unit/test_bot/test_settings_dispatcher.py
+++ b/tests/unit/test_bot/test_settings_dispatcher.py
@@ -9,6 +9,7 @@ import pytest
 
 from src.bot.handlers.settings.dispatcher import SettingsDispatcher
 from src.enums import SubscriptionType
+from tests.constants import TIMEZONE_EUROPE_MOSCOW
 from tests.unit.utils.fake_container import FakeServiceContainer
 
 
@@ -300,3 +301,135 @@ class TestSettingsDispatcher:
                     mock_send_error.assert_called_once()
                     args = mock_send_error.call_args.kwargs
                     assert "pgettext_settings.error_" in args["error_message"]
+
+
+class TestSettingsDispatcherTimezoneDisplay:
+    """Test suite for timezone display in settings menu.
+
+    Covers timezone_val logic: profile.settings.timezone or UTC fallback.
+    """
+
+    @pytest.fixture
+    def handler(self) -> SettingsDispatcher:
+        """Create SettingsDispatcher instance for testing.
+
+        :returns: Configured SettingsDispatcher instance
+        :rtype: SettingsDispatcher
+        """
+        services = FakeServiceContainer()
+        services.user_service = MagicMock()
+        return SettingsDispatcher(services)
+
+    @pytest.fixture(autouse=True)
+    def mock_use_locale(self, mocker) -> MagicMock:
+        """Mock use_locale to control translations.
+
+        :param mocker: pytest-mock fixture
+        :type mocker: pytest_mock.MockerFixture
+        :returns: Mocked pgettext function
+        :rtype: MagicMock
+        """
+        mock_pgettext = MagicMock(side_effect=lambda c, m: f"pgettext_{c}_{m}")
+        mocker.patch(
+            "src.bot.handlers.settings.dispatcher.use_locale",
+            return_value=(None, None, mock_pgettext),
+        )
+        return mock_pgettext
+
+    @pytest.mark.asyncio
+    async def test_handle_settings_displays_timezone_when_set(
+        self,
+        handler: SettingsDispatcher,
+        mock_update: MagicMock,
+        mock_context: MagicMock,
+    ) -> None:
+        """Test that settings menu displays user timezone when set.
+
+        :param handler: SettingsDispatcher instance
+        :type handler: SettingsDispatcher
+        :param mock_update: Mocked update
+        :type mock_update: MagicMock
+        :param mock_context: Mocked context
+        :type mock_context: MagicMock
+        :returns: None
+        """
+        from src.bot.handlers.base_handler import CommandContext
+
+        mock_profile = MagicMock()
+        mock_profile.is_premium = True
+        mock_profile.subscription.subscription_type = SubscriptionType.PREMIUM
+        mock_profile.settings.language = "en"
+        mock_profile.settings.life_expectancy = 80
+        mock_profile.settings.birth_date = None
+        mock_profile.settings.timezone = TIMEZONE_EUROPE_MOSCOW
+
+        mock_cmd_context = CommandContext(
+            user=mock_update.effective_user,
+            user_id=mock_update.effective_user.id,
+            language="en",
+            user_profile=mock_profile,
+        )
+
+        async def mock_extract_fn(*args, **kwargs):
+            return mock_cmd_context
+
+        with patch.object(
+            handler, "_extract_command_context", side_effect=mock_extract_fn
+        ):
+            with patch.object(handler, "send_message") as mock_send_message, patch(
+                "src.bot.handlers.settings.dispatcher.get_settings_keyboard"
+            ):
+                await handler._handle_settings(mock_update, mock_context)
+
+                mock_send_message.assert_called_once()
+                args = mock_send_message.call_args.kwargs
+                assert TIMEZONE_EUROPE_MOSCOW in args["message_text"]
+
+    @pytest.mark.asyncio
+    async def test_handle_settings_displays_utc_when_timezone_none(
+        self,
+        handler: SettingsDispatcher,
+        mock_update: MagicMock,
+        mock_context: MagicMock,
+    ) -> None:
+        """Test that settings menu displays UTC when timezone is None.
+
+        :param handler: SettingsDispatcher instance
+        :type handler: SettingsDispatcher
+        :param mock_update: Mocked update
+        :type mock_update: MagicMock
+        :param mock_context: Mocked context
+        :type mock_context: MagicMock
+        :returns: None
+        """
+        from src.bot.handlers.base_handler import CommandContext
+
+        mock_profile = MagicMock()
+        mock_profile.is_premium = True
+        mock_profile.subscription.subscription_type = SubscriptionType.PREMIUM
+        mock_profile.settings.language = "en"
+        mock_profile.settings.life_expectancy = 80
+        mock_profile.settings.birth_date = None
+        mock_profile.settings.timezone = None
+
+        mock_cmd_context = CommandContext(
+            user=mock_update.effective_user,
+            user_id=mock_update.effective_user.id,
+            language="en",
+            user_profile=mock_profile,
+        )
+
+        async def mock_extract_fn(*args, **kwargs):
+            return mock_cmd_context
+
+        with patch.object(
+            handler, "_extract_command_context", side_effect=mock_extract_fn
+        ):
+            with patch.object(handler, "send_message") as mock_send_message, patch(
+                "src.bot.handlers.settings.dispatcher.get_settings_keyboard"
+            ):
+                await handler._handle_settings(mock_update, mock_context)
+
+                mock_send_message.assert_called_once()
+                args = mock_send_message.call_args.kwargs
+                assert "UTC" in args["message_text"]

--- a/tests/unit/test_bot/test_settings_dispatcher.py
+++ b/tests/unit/test_bot/test_settings_dispatcher.py
@@ -3,14 +3,62 @@
 Tests the SettingsDispatcher class which handles the main settings menu.
 """
 
+from datetime import date
 from unittest.mock import MagicMock, patch
 
 import pytest
 
+from src.bot.constants import COMMAND_SETTINGS
+from src.bot.handlers.base_handler import CommandContext
 from src.bot.handlers.settings.dispatcher import SettingsDispatcher
 from src.enums import SubscriptionType
+from tests.conftest import TEST_BIRTH_DAY, TEST_BIRTH_MONTH, TEST_BIRTH_YEAR
 from tests.constants import TIMEZONE_EUROPE_MOSCOW
 from tests.unit.utils.fake_container import FakeServiceContainer
+
+# Test constants for birth date formatting
+TEST_BIRTH_DATE: date = date(TEST_BIRTH_YEAR, TEST_BIRTH_MONTH, TEST_BIRTH_DAY)
+EXPECTED_BIRTH_DATE_FORMAT: str = "15.03.1990"
+
+
+def _make_cmd_context(
+    mock_update: MagicMock,
+    user_profile: MagicMock | None,
+    language: str = "en",
+) -> CommandContext:
+    """Create CommandContext for testing.
+
+    :param mock_update: Mocked Telegram update
+    :type mock_update: MagicMock
+    :param user_profile: User profile or None
+    :type user_profile: MagicMock | None
+    :param language: Language code
+    :type language: str
+    :returns: CommandContext instance
+    :rtype: CommandContext
+    """
+    return CommandContext(
+        user=mock_update.effective_user,
+        user_id=mock_update.effective_user.id,
+        language=language,
+        user_profile=user_profile,
+    )
+
+
+class TestSettingsDispatcherInit:
+    """Test suite for SettingsDispatcher initialization."""
+
+    def test_init_sets_command_name(self) -> None:
+        """Test that __init__ sets command_name to /settings.
+
+        Verifies that SettingsDispatcher initializes with correct
+        command name from COMMAND_SETTINGS constant.
+
+        :returns: None
+        """
+        services = FakeServiceContainer()
+        handler = SettingsDispatcher(services)
+        assert handler.command_name == f"/{COMMAND_SETTINGS}"
 
 
 class TestSettingsDispatcher:
@@ -63,9 +111,6 @@ class TestSettingsDispatcher:
         :type mock_context: MagicMock
         :returns: None
         """
-        # Setup basic user profile
-        from src.bot.handlers.base_handler import CommandContext
-
         mock_profile = MagicMock()
         mock_profile.is_premium = False
         mock_profile.subscription.subscription_type = SubscriptionType.BASIC
@@ -73,13 +118,7 @@ class TestSettingsDispatcher:
         mock_profile.settings.life_expectancy = 80
         mock_profile.settings.birth_date = None
 
-        # Mock _extract_command_context to return proper CommandContext
-        mock_cmd_context = CommandContext(
-            user=mock_update.effective_user,
-            user_id=mock_update.effective_user.id,
-            language="en",
-            user_profile=mock_profile,
-        )
+        mock_cmd_context = _make_cmd_context(mock_update, mock_profile)
 
         async def mock_extract_fn(*args, **kwargs):
             return mock_cmd_context
@@ -129,9 +168,6 @@ class TestSettingsDispatcher:
         :type mock_context: MagicMock
         :returns: None
         """
-        # Setup premium user profile
-        from src.bot.handlers.base_handler import CommandContext
-
         mock_profile = MagicMock()
         mock_profile.is_premium = True
         mock_profile.subscription.subscription_type = SubscriptionType.PREMIUM
@@ -139,13 +175,7 @@ class TestSettingsDispatcher:
         mock_profile.settings.life_expectancy = 80
         mock_profile.settings.birth_date = None
 
-        # Mock _extract_command_context to return proper CommandContext
-        mock_cmd_context = CommandContext(
-            user=mock_update.effective_user,
-            user_id=mock_update.effective_user.id,
-            language="en",
-            user_profile=mock_profile,
-        )
+        mock_cmd_context = _make_cmd_context(mock_update, mock_profile)
 
         async def mock_extract_fn(*args, **kwargs):
             return mock_cmd_context
@@ -269,8 +299,6 @@ class TestSettingsDispatcher:
         :type mock_context: MagicMock
         :returns: None
         """
-        from src.bot.handlers.base_handler import CommandContext
-
         mock_profile = MagicMock()
         mock_profile.is_premium = False
         mock_profile.subscription.subscription_type = SubscriptionType.BASIC
@@ -278,12 +306,7 @@ class TestSettingsDispatcher:
         mock_profile.settings.life_expectancy = 80
         mock_profile.settings.birth_date = None
 
-        mock_cmd_context = CommandContext(
-            user=mock_update.effective_user,
-            user_id=mock_update.effective_user.id,
-            language="en",
-            user_profile=mock_profile,
-        )
+        mock_cmd_context = _make_cmd_context(mock_update, mock_profile)
 
         async def mock_extract(*args, **kwargs):
             return mock_cmd_context
@@ -353,8 +376,6 @@ class TestSettingsDispatcherTimezoneDisplay:
         :type mock_context: MagicMock
         :returns: None
         """
-        from src.bot.handlers.base_handler import CommandContext
-
         mock_profile = MagicMock()
         mock_profile.is_premium = True
         mock_profile.subscription.subscription_type = SubscriptionType.PREMIUM
@@ -363,12 +384,7 @@ class TestSettingsDispatcherTimezoneDisplay:
         mock_profile.settings.birth_date = None
         mock_profile.settings.timezone = TIMEZONE_EUROPE_MOSCOW
 
-        mock_cmd_context = CommandContext(
-            user=mock_update.effective_user,
-            user_id=mock_update.effective_user.id,
-            language="en",
-            user_profile=mock_profile,
-        )
+        mock_cmd_context = _make_cmd_context(mock_update, mock_profile)
 
         async def mock_extract_fn(*args, **kwargs):
             return mock_cmd_context
@@ -402,8 +418,6 @@ class TestSettingsDispatcherTimezoneDisplay:
         :type mock_context: MagicMock
         :returns: None
         """
-        from src.bot.handlers.base_handler import CommandContext
-
         mock_profile = MagicMock()
         mock_profile.is_premium = True
         mock_profile.subscription.subscription_type = SubscriptionType.PREMIUM
@@ -412,12 +426,7 @@ class TestSettingsDispatcherTimezoneDisplay:
         mock_profile.settings.birth_date = None
         mock_profile.settings.timezone = None
 
-        mock_cmd_context = CommandContext(
-            user=mock_update.effective_user,
-            user_id=mock_update.effective_user.id,
-            language="en",
-            user_profile=mock_profile,
-        )
+        mock_cmd_context = _make_cmd_context(mock_update, mock_profile)
 
         async def mock_extract_fn(*args, **kwargs):
             return mock_cmd_context
@@ -433,3 +442,210 @@ class TestSettingsDispatcherTimezoneDisplay:
                 mock_send_message.assert_called_once()
                 args = mock_send_message.call_args.kwargs
                 assert "UTC" in args["message_text"]
+
+
+class TestSettingsDispatcherEdgeCases:
+    """Test suite for edge cases in settings dispatcher.
+
+    Covers profile=None, birth_date formatting, profile.settings=None,
+    and life_expectancy fallback branches.
+    """
+
+    @pytest.fixture
+    def handler(self) -> SettingsDispatcher:
+        """Create SettingsDispatcher instance for testing.
+
+        :returns: Configured SettingsDispatcher instance
+        :rtype: SettingsDispatcher
+        """
+        services = FakeServiceContainer()
+        services.user_service = MagicMock()
+        return SettingsDispatcher(services)
+
+    @pytest.fixture(autouse=True)
+    def mock_use_locale(self, mocker) -> MagicMock:
+        """Mock use_locale to control translations.
+
+        :param mocker: pytest-mock fixture
+        :type mocker: pytest_mock.MockerFixture
+        :returns: Mocked pgettext function
+        :rtype: MagicMock
+        """
+        mock_pgettext = MagicMock(side_effect=lambda c, m: f"pgettext_{c}_{m}")
+        mocker.patch(
+            "src.bot.handlers.settings.dispatcher.use_locale",
+            return_value=(None, None, mock_pgettext),
+        )
+        return mock_pgettext
+
+    @pytest.mark.asyncio
+    async def test_handle_settings_profile_none(
+        self,
+        handler: SettingsDispatcher,
+        mock_update: MagicMock,
+        mock_context: MagicMock,
+    ) -> None:
+        """Test _handle_settings when user_profile is None.
+
+        Verifies is_premium=False, birth_date shows 'Not set',
+        and send_message is called without raising.
+
+        :param handler: SettingsDispatcher instance
+        :type handler: SettingsDispatcher
+        :param mock_update: Mocked update
+        :type mock_update: MagicMock
+        :param mock_context: Mocked context
+        :type mock_context: MagicMock
+        :returns: None
+        """
+        mock_cmd_context = _make_cmd_context(mock_update, user_profile=None)
+
+        async def mock_extract_fn(*args, **kwargs):
+            return mock_cmd_context
+
+        with patch.object(
+            handler, "_extract_command_context", side_effect=mock_extract_fn
+        ):
+            with patch.object(handler, "send_message") as mock_send_message, patch(
+                "src.bot.handlers.settings.dispatcher.get_settings_keyboard"
+            ):
+                await handler._handle_settings(mock_update, mock_context)
+
+                mock_send_message.assert_called_once()
+                args = mock_send_message.call_args.kwargs
+                assert "pgettext_not.set_Not set" in args["message_text"]
+                assert "pgettext_settings.basic" in args["message_text"]
+
+    @pytest.mark.asyncio
+    async def test_handle_settings_birth_date_formatted(
+        self,
+        handler: SettingsDispatcher,
+        mock_update: MagicMock,
+        mock_context: MagicMock,
+    ) -> None:
+        """Test that birth_date is formatted via format_date when set.
+
+        Verifies format_date branch with actual date value.
+
+        :param handler: SettingsDispatcher instance
+        :type handler: SettingsDispatcher
+        :param mock_update: Mocked update
+        :type mock_update: MagicMock
+        :param mock_context: Mocked context
+        :type mock_context: MagicMock
+        :returns: None
+        """
+        mock_profile = MagicMock()
+        mock_profile.is_premium = False
+        mock_profile.subscription.subscription_type = SubscriptionType.BASIC
+        mock_profile.settings.language = "en"
+        mock_profile.settings.life_expectancy = 80
+        mock_profile.settings.birth_date = TEST_BIRTH_DATE
+
+        mock_cmd_context = _make_cmd_context(mock_update, mock_profile)
+
+        async def mock_extract_fn(*args, **kwargs):
+            return mock_cmd_context
+
+        with patch.object(
+            handler, "_extract_command_context", side_effect=mock_extract_fn
+        ):
+            with patch.object(handler, "send_message") as mock_send_message, patch(
+                "src.bot.handlers.settings.dispatcher.get_settings_keyboard"
+            ), patch(
+                "src.bot.handlers.settings.dispatcher.format_date",
+                return_value=EXPECTED_BIRTH_DATE_FORMAT,
+            ):
+                await handler._handle_settings(mock_update, mock_context)
+
+                mock_send_message.assert_called_once()
+                args = mock_send_message.call_args.kwargs
+                assert EXPECTED_BIRTH_DATE_FORMAT in args["message_text"]
+
+    @pytest.mark.asyncio
+    async def test_handle_settings_profile_settings_none(
+        self,
+        handler: SettingsDispatcher,
+        mock_update: MagicMock,
+        mock_context: MagicMock,
+    ) -> None:
+        """Test _handle_settings when profile.settings is None.
+
+        Verifies no crash, birth_date='Not set', life_expectancy=80,
+        timezone='UTC' via getattr fallbacks.
+
+        :param handler: SettingsDispatcher instance
+        :type handler: SettingsDispatcher
+        :param mock_update: Mocked update
+        :type mock_update: MagicMock
+        :param mock_context: Mocked context
+        :type mock_context: MagicMock
+        :returns: None
+        """
+        mock_profile = MagicMock()
+        mock_profile.is_premium = False
+        mock_profile.subscription.subscription_type = SubscriptionType.BASIC
+        mock_profile.settings = None
+
+        mock_cmd_context = _make_cmd_context(mock_update, mock_profile)
+
+        async def mock_extract_fn(*args, **kwargs):
+            return mock_cmd_context
+
+        with patch.object(
+            handler, "_extract_command_context", side_effect=mock_extract_fn
+        ):
+            with patch.object(handler, "send_message") as mock_send_message, patch(
+                "src.bot.handlers.settings.dispatcher.get_settings_keyboard"
+            ):
+                await handler._handle_settings(mock_update, mock_context)
+
+                mock_send_message.assert_called_once()
+                args = mock_send_message.call_args.kwargs
+                assert "pgettext_not.set_Not set" in args["message_text"]
+                assert "80" in args["message_text"]
+                assert "UTC" in args["message_text"]
+
+    @pytest.mark.asyncio
+    async def test_handle_settings_life_expectancy_fallback(
+        self,
+        handler: SettingsDispatcher,
+        mock_update: MagicMock,
+        mock_context: MagicMock,
+    ) -> None:
+        """Test life_expectancy fallback to 80 when None.
+
+        Verifies 'or 80' branch when getattr returns None.
+
+        :param handler: SettingsDispatcher instance
+        :type handler: SettingsDispatcher
+        :param mock_update: Mocked update
+        :type mock_update: MagicMock
+        :param mock_context: Mocked context
+        :type mock_context: MagicMock
+        :returns: None
+        """
+        mock_profile = MagicMock()
+        mock_profile.is_premium = False
+        mock_profile.subscription.subscription_type = SubscriptionType.BASIC
+        mock_profile.settings.language = "en"
+        mock_profile.settings.life_expectancy = None
+        mock_profile.settings.birth_date = None
+        mock_profile.settings.timezone = None
+
+        mock_cmd_context = _make_cmd_context(mock_update, mock_profile)
+
+        async def mock_extract_fn(*args, **kwargs):
+            return mock_cmd_context
+
+        with patch.object(
+            handler, "_extract_command_context", side_effect=mock_extract_fn
+        ):
+            with patch.object(handler, "send_message") as mock_send_message, patch(
+                "src.bot.handlers.settings.dispatcher.get_settings_keyboard"
+            ):
+                await handler._handle_settings(mock_update, mock_context)
+
+                mock_send_message.assert_called_once()
+                args = mock_send_message.call_args.kwargs
+                assert "80" in args["message_text"]

--- a/tests/unit/test_bot/test_settings_keyboards.py
+++ b/tests/unit/test_bot/test_settings_keyboards.py
@@ -12,6 +12,15 @@ from src.bot.handlers.settings.keyboards import (
     get_settings_keyboard,
     get_timezone_keyboard,
 )
+from tests.constants import (
+    CALLBACK_SETTINGS_TIMEZONE,
+    CALLBACK_TIMEZONE_MINSK,
+    CALLBACK_TIMEZONE_MOSCOW,
+    CALLBACK_TIMEZONE_NEW_YORK,
+    CALLBACK_TIMEZONE_OTHER,
+    CALLBACK_TIMEZONE_UTC,
+    CALLBACK_TIMEZONE_WARSAW,
+)
 
 
 class TestSettingsKeyboards:
@@ -35,7 +44,7 @@ class TestSettingsKeyboards:
         callback_data = [
             btn.callback_data for row in keyboard.inline_keyboard for btn in row
         ]
-        assert "settings_timezone" not in callback_data
+        assert CALLBACK_SETTINGS_TIMEZONE not in callback_data
         assert "settings_notification_schedule" not in callback_data
 
     def test_get_settings_keyboard_premium(self) -> None:
@@ -48,7 +57,7 @@ class TestSettingsKeyboards:
         callback_data = [
             btn.callback_data for row in keyboard.inline_keyboard for btn in row
         ]
-        assert "settings_timezone" in callback_data
+        assert CALLBACK_SETTINGS_TIMEZONE in callback_data
         assert "settings_notification_schedule" in callback_data
 
     def test_get_timezone_keyboard(self) -> None:
@@ -62,11 +71,11 @@ class TestSettingsKeyboards:
             btn.callback_data for row in keyboard.inline_keyboard for btn in row
         ]
         expected_callbacks = [
-            "timezone_UTC",
-            "timezone_Europe/Moscow",
-            "timezone_Europe/Warsaw",
-            "timezone_Europe/Minsk",
-            "timezone_America/New_York",
-            "timezone_other",
+            CALLBACK_TIMEZONE_UTC,
+            CALLBACK_TIMEZONE_MOSCOW,
+            CALLBACK_TIMEZONE_WARSAW,
+            CALLBACK_TIMEZONE_MINSK,
+            CALLBACK_TIMEZONE_NEW_YORK,
+            CALLBACK_TIMEZONE_OTHER,
         ]
         assert callback_data == expected_callbacks

--- a/tests/unit/test_bot/test_start_handler.py
+++ b/tests/unit/test_bot/test_start_handler.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from src.bot.constants import DEFAULT_TIMEZONE_MAPPING, FALLBACK_TIMEZONE
 from src.bot.handlers.start_handler import StartHandler
 from src.database.service import UserRegistrationError, UserServiceError
 from src.events.domain_events import UserSettingsChangedEvent
@@ -613,3 +614,112 @@ class TestStartHandler:
 
         # Verify state cleared
         assert "waiting_for" not in mock_context.user_data
+
+
+class TestStartHandlerGuessTimezoneFromLanguage:
+    """Test suite for StartHandler._guess_timezone_from_language method.
+
+    Covers timezone mapping by language code and fallback for unknown languages.
+    """
+
+    @pytest.fixture
+    def handler(self) -> StartHandler:
+        """Create StartHandler instance with fake container.
+
+        :returns: StartHandler instance
+        :rtype: StartHandler
+        """
+        return StartHandler(FakeServiceContainer())
+
+    def test_guess_timezone_ru(self, handler: StartHandler) -> None:
+        """Test timezone for Russian language code.
+
+        :param handler: StartHandler instance
+        :type handler: StartHandler
+        :returns: None
+        """
+        assert (
+            handler._guess_timezone_from_language("ru")
+            == DEFAULT_TIMEZONE_MAPPING["ru"]
+        )
+
+    def test_guess_timezone_en(self, handler: StartHandler) -> None:
+        """Test timezone for English language code.
+
+        :param handler: StartHandler instance
+        :type handler: StartHandler
+        :returns: None
+        """
+        assert (
+            handler._guess_timezone_from_language("en")
+            == DEFAULT_TIMEZONE_MAPPING["en"]
+        )
+
+    def test_guess_timezone_ua(self, handler: StartHandler) -> None:
+        """Test timezone for Ukrainian language code.
+
+        :param handler: StartHandler instance
+        :type handler: StartHandler
+        :returns: None
+        """
+        assert (
+            handler._guess_timezone_from_language("ua")
+            == DEFAULT_TIMEZONE_MAPPING["ua"]
+        )
+
+    def test_guess_timezone_by(self, handler: StartHandler) -> None:
+        """Test timezone for Belarusian (by) language code.
+
+        :param handler: StartHandler instance
+        :type handler: StartHandler
+        :returns: None
+        """
+        assert (
+            handler._guess_timezone_from_language("by")
+            == DEFAULT_TIMEZONE_MAPPING["by"]
+        )
+
+    def test_guess_timezone_be(self, handler: StartHandler) -> None:
+        """Test timezone for Belarusian (be) language code.
+
+        :param handler: StartHandler instance
+        :type handler: StartHandler
+        :returns: None
+        """
+        assert (
+            handler._guess_timezone_from_language("be")
+            == DEFAULT_TIMEZONE_MAPPING["be"]
+        )
+
+    def test_guess_timezone_uk(self, handler: StartHandler) -> None:
+        """Test timezone for Ukrainian (uk) language code.
+
+        :param handler: StartHandler instance
+        :type handler: StartHandler
+        :returns: None
+        """
+        assert (
+            handler._guess_timezone_from_language("uk")
+            == DEFAULT_TIMEZONE_MAPPING["uk"]
+        )
+
+    def test_guess_timezone_unknown_fallback(self, handler: StartHandler) -> None:
+        """Test fallback timezone for unknown language code.
+
+        :param handler: StartHandler instance
+        :type handler: StartHandler
+        :returns: None
+        """
+        assert handler._guess_timezone_from_language("xx") == FALLBACK_TIMEZONE
+
+    def test_guess_timezone_lang_code_with_region(self, handler: StartHandler) -> None:
+        """Test that lang_code with region uses first 2 chars.
+
+        :param handler: StartHandler instance
+        :type handler: StartHandler
+        :returns: None
+        """
+        assert (
+            handler._guess_timezone_from_language("ru-RU")
+            == DEFAULT_TIMEZONE_MAPPING["ru"]
+        )

--- a/tests/unit/test_bot/test_timezone_handler.py
+++ b/tests/unit/test_bot/test_timezone_handler.py
@@ -8,10 +8,18 @@ from telegram.ext import ContextTypes
 
 from src.bot.conversations.states import ConversationState
 from src.bot.handlers.settings.timezone_handler import TimezoneHandler
+from src.constants import DEFAULT_TIMEZONE
 from src.core.dtos import UserProfileDTO, UserSettingsDTO
 from src.database.service import UserSettingsUpdateError
 from src.enums import NotificationFrequency
 from src.events.domain_events import UserSettingsChangedEvent
+from tests.constants import (
+    CALLBACK_TIMEZONE_EUROPE_LONDON,
+    CALLBACK_TIMEZONE_OTHER,
+    TIMEZONE_AMERICA_NEW_YORK,
+    TIMEZONE_EUROPE_LONDON,
+    TIMEZONE_INVALID,
+)
 from tests.unit.utils.fake_container import FakeServiceContainer
 
 
@@ -43,7 +51,7 @@ class TestTimezoneHandler:
                     notification_frequency=NotificationFrequency.DAILY,
                     notifications_month_day=None,
                     life_expectancy=None,
-                    timezone="UTC",
+                    timezone=DEFAULT_TIMEZONE,
                     language="en",
                 ),
                 subscription=None,
@@ -132,7 +140,7 @@ class TestTimezoneHandler:
         mock_pgettext = MagicMock(return_value="Enter timezone")
         mock_use_locale.return_value = (None, None, mock_pgettext)
 
-        update_mock.callback_query.data = "timezone_other"
+        update_mock.callback_query.data = CALLBACK_TIMEZONE_OTHER
 
         handler._extract_command_context = AsyncMock()
         handler._extract_command_context.return_value.user_id = 123
@@ -162,7 +170,7 @@ class TestTimezoneHandler:
         mock_pgettext = MagicMock(return_value="Success")
         mock_use_locale.return_value = (None, None, mock_pgettext)
 
-        update_mock.callback_query.data = "timezone_Europe/London"
+        update_mock.callback_query.data = CALLBACK_TIMEZONE_EUROPE_LONDON
 
         handler._extract_command_context = AsyncMock()
         handler._extract_command_context.return_value.user_id = 123
@@ -174,13 +182,13 @@ class TestTimezoneHandler:
         # Verify
         assert result is None
         handler.services.user_service.update_user_settings.assert_called_once_with(
-            telegram_id=123, timezone="Europe/London"
+            telegram_id=123, timezone=TIMEZONE_EUROPE_LONDON
         )
         handler.services.event_bus.publish.assert_called_once()
         event = handler.services.event_bus.publish.call_args[0][0]
         assert isinstance(event, UserSettingsChangedEvent)
         assert event.setting_name == "timezone"
-        assert event.new_value == "Europe/London"
+        assert event.new_value == TIMEZONE_EUROPE_LONDON
 
         handler.edit_message.assert_called_once_with(
             query=update_mock.callback_query,
@@ -201,7 +209,7 @@ class TestTimezoneHandler:
         mock_pgettext = MagicMock(return_value="Error")
         mock_use_locale.return_value = (None, None, mock_pgettext)
 
-        update_mock.callback_query.data = "timezone_Europe/London"
+        update_mock.callback_query.data = CALLBACK_TIMEZONE_EUROPE_LONDON
 
         handler._extract_command_context = AsyncMock()
         handler._extract_command_context.return_value.user_id = 123
@@ -235,7 +243,7 @@ class TestTimezoneHandler:
         mock_pgettext = MagicMock(return_value="Success")
         mock_use_locale.return_value = (None, None, mock_pgettext)
 
-        update_mock.message.text = "America/New_York"
+        update_mock.message.text = TIMEZONE_AMERICA_NEW_YORK
 
         handler._extract_command_context = AsyncMock()
         handler._extract_command_context.return_value.user_id = 123
@@ -246,7 +254,7 @@ class TestTimezoneHandler:
         # Verify
         assert result == ConversationState.IDLE.value
         handler.services.user_service.update_user_settings.assert_called_once_with(
-            telegram_id=123, timezone="America/New_York"
+            telegram_id=123, timezone=TIMEZONE_AMERICA_NEW_YORK
         )
         update_mock.message.reply_text.assert_called_once_with(
             "Success", parse_mode="HTML"
@@ -266,7 +274,7 @@ class TestTimezoneHandler:
         mock_pgettext = MagicMock(return_value="Invalid")
         mock_use_locale.return_value = (None, None, mock_pgettext)
 
-        update_mock.message.text = "Invalid/Timezone"
+        update_mock.message.text = TIMEZONE_INVALID
 
         handler._extract_command_context = AsyncMock()
         handler._extract_command_context.return_value.user_id = 123
@@ -293,7 +301,7 @@ class TestTimezoneHandler:
         mock_pgettext = MagicMock(return_value="Outer Error")
         mock_use_locale.return_value = (None, None, mock_pgettext)
 
-        update_mock.callback_query.data = "timezone_other"
+        update_mock.callback_query.data = CALLBACK_TIMEZONE_OTHER
 
         handler._extract_command_context = AsyncMock()
         handler._extract_command_context.return_value.user_id = 123
@@ -327,7 +335,7 @@ class TestTimezoneHandler:
         mock_pgettext = MagicMock(return_value="Outer Input Error")
         mock_use_locale.return_value = (None, None, mock_pgettext)
 
-        update_mock.message.text = "UTC"
+        update_mock.message.text = DEFAULT_TIMEZONE
 
         handler._extract_command_context = AsyncMock()
         handler._extract_command_context.return_value.user_id = 123
@@ -359,7 +367,7 @@ class TestTimezoneHandler:
         )
 
         result = await handler._update_timezone(
-            timezone_value="UTC",
+            timezone_value=DEFAULT_TIMEZONE,
             user_id=123,
             lang="en",
             query=None,

--- a/tests/unit/test_database/test_service.py
+++ b/tests/unit/test_database/test_service.py
@@ -1289,6 +1289,41 @@ class TestUserServiceUpdateSettings:
         )
 
     @pytest.mark.asyncio
+    async def test_update_user_settings_timezone_success(self) -> None:
+        """Test successful settings update with timezone field.
+
+        This test verifies that update_user_settings correctly
+        updates the timezone field via _apply_settings_updates.
+
+        :returns: None
+        :rtype: None
+        """
+        from tests.constants import TIMEZONE_EUROPE_MOSCOW
+
+        user_service = UserService()
+        settings = MagicMock()
+        settings.birth_date = date(1990, 1, 1)
+        settings.life_expectancy = 75
+        settings.language = SupportedLanguage.EN.value
+        settings.timezone = "UTC"
+
+        user_service.settings_repository = MagicMock()
+        user_service.settings_repository.get_user_settings = AsyncMock()
+        user_service.settings_repository.update_user_settings = AsyncMock()
+        user_service.settings_repository.delete_user_settings = AsyncMock()
+        user_service.settings_repository.get_user_settings.return_value = settings
+        user_service.settings_repository.update_user_settings.return_value = True
+
+        await user_service.update_user_settings(
+            123456789, timezone=TIMEZONE_EUROPE_MOSCOW
+        )
+
+        assert settings.timezone == TIMEZONE_EUROPE_MOSCOW
+        user_service.settings_repository.update_user_settings.assert_called_once_with(
+            settings=settings
+        )
+
+    @pytest.mark.asyncio
     async def test_update_user_settings_not_found(self) -> None:
         """Test update_user_settings when settings not found.
 


### PR DESCRIPTION
Add comprehensive integration test suite for timezone functionality covering registration defaults, handler flows, scheduler application, and output verification across all supported languages.

Functional Changes:
- No functional changes to application code

Refactoring Changes:
- Add make_trial_user helper to conftest for Trial subscription users
- Add setup_timezone_callback helper for timezone handler callback flow

Test Changes:
- Add test_settings_timezone.py with 51 parametrized E2E tests
- TestTimezoneRegistrationDefaults: default timezone on registration per language (6 tests)
- TestTimezoneHandlerPremiumUser: callback menu, keyboard selection, manual IANA input, invalid input, Other flow (parametrized by SupportedLanguage)
- TestTimezoneHandlerTrialUser: Trial user timezone access
- TestTimezoneHandlerBasicUser: Basic user has no timezone button in settings
- TestTimezoneSchedulerApplication: event listener and scheduler receive correct trigger with timezone
- TestTimezoneOutputAllLanguages: success and invalid messages in all 6 languages
- Use constants (DEFAULT_TIMEZONE_MAPPING, FALLBACK_TIMEZONE) instead of magic values
- Class-scoped handler fixtures for test performance

Made-with: Cursor