### PR TITLE
fix(database): normalize notifications_day enum values to lowercase

### DIFF
--- a/alembic/versions/0006_normalize_notifications_day_to_lowercase.py
+++ b/alembic/versions/0006_normalize_notifications_day_to_lowercase.py
@@ -1,0 +1,32 @@
+"""Normalize notifications_day values to lowercase.
+
+Existing records may contain uppercase enum member names (MONDAY, TUESDAY, ...)
+written before the model adopted values_callable. The ORM now expects lowercase
+values (monday, tuesday, ...) matching StrEnum.auto() output.
+
+Revision ID: 0006
+Revises: 0005
+Create Date: 2026-03-14
+"""
+
+from alembic import op
+
+revision = "0006"
+down_revision = "0005"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Normalize notifications_day column values to lowercase."""
+    op.execute(
+        "UPDATE user_settings "
+        "SET notifications_day = LOWER(notifications_day) "
+        "WHERE notifications_day IS NOT NULL "
+        "AND notifications_day != LOWER(notifications_day)"
+    )
+
+
+def downgrade() -> None:
+    """No-op: lowercase values are valid for both old and new model variants."""
+    pass


### PR DESCRIPTION
Add Alembic data migration 0006 to fix WeekDay enum mismatch after migration 0005 deployment. Existing user_settings records contain uppercase values (MONDAY, TUESDAY, ...) written before the model adopted values_callable, while the ORM now expects lowercase values (monday, tuesday, ...) matching StrEnum.auto() output.

Functional Changes:
- Add migration 0006_normalize_notifications_day_to_lowercase.py
- Normalize notifications_day column: UPDATE ... SET LOWER() for all uppercase enum values in user_settings table
- Resolve 'MONDAY is not among the defined enum values' error that blocks user profile loading and scheduled job restoration
- Fix critical regression where existing users are treated as unregistered after migration 0005 deployment